### PR TITLE
limit frame and refresh page

### DIFF
--- a/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_Nano_V1_Capture/ArduCAM_ESP8266_Nano_V1_Capture.ino
+++ b/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_Nano_V1_Capture/ArduCAM_ESP8266_Nano_V1_Capture.ino
@@ -161,11 +161,18 @@ void serverStream()
   WiFiClient client = server.client();
 
   String response = "HTTP/1.1 200 OK\r\n";
+  response += "Refresh: 1; url=/stream\r\n";
   response += "Content-Type: multipart/x-mixed-replace; boundary=frame\r\n\r\n";
   server.sendContent(response);
-
+  int cnt = 0;
   while (1)
   {
+    cnt++;
+    if(cnt > 100){
+      client.stop();
+      is_header = false;
+      break;
+    }
     start_capture();
     while (!myCAM.get_bit(ARDUCHIP_TRIG, CAP_DONE_MASK));
     size_t len = myCAM.read_fifo_length();

--- a/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_Nano_V2_Capture/ArduCAM_ESP8266_Nano_V2_Capture.ino
+++ b/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_Nano_V2_Capture/ArduCAM_ESP8266_Nano_V2_Capture.ino
@@ -165,11 +165,18 @@ void serverStream()
   WiFiClient client = server.client();
 
   String response = "HTTP/1.1 200 OK\r\n";
+  response += "Refresh: 1; url=/stream\r\n";
   response += "Content-Type: multipart/x-mixed-replace; boundary=frame\r\n\r\n";
   server.sendContent(response);
-
+  int cnt = 0;
   while (1)
   {
+    cnt++;
+    if(cnt > 100){
+      client.stop();
+      is_header = false;
+      break;
+    }
     start_capture();
     while (!myCAM.get_bit(ARDUCHIP_TRIG, CAP_DONE_MASK));
     size_t len = myCAM.read_fifo_length();

--- a/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_UNO_Capture/ArduCAM_ESP8266_UNO_Capture.ino
+++ b/libraries/ArduCAM/examples/examples/ESP8266/ArduCAM_ESP8266_UNO_Capture/ArduCAM_ESP8266_UNO_Capture.ino
@@ -159,11 +159,18 @@ void serverStream()
   WiFiClient client = server.client();
 
   String response = "HTTP/1.1 200 OK\r\n";
+  response += "Refresh: 1; url=/stream\r\n";
   response += "Content-Type: multipart/x-mixed-replace; boundary=frame\r\n\r\n";
   server.sendContent(response);
-
+  int cnt = 0;
   while (1)
   {
+    cnt++;
+    if(cnt > 100){
+      client.stop();
+      is_header = false;
+      break;
+    }
     start_capture();
     while (!myCAM.get_bit(ARDUCHIP_TRIG, CAP_DONE_MASK));
     size_t len = myCAM.read_fifo_length();


### PR DESCRIPTION
# update example for stream browser

I was has problem with showing black image on video stream after running 4min 

I think that was kinds of memory leak problem

I used frame limits and http refresh meta data for the solving problem

it will refresh page after every 100 mjpeg frame